### PR TITLE
Upgrade all dependencies: Spring Boot 4.0.4, Kotlin 2.3.0, Jackson 3,…

### DIFF
--- a/.github/workflows/bygg_alle_brancher.yml
+++ b/.github/workflows/bygg_alle_brancher.yml
@@ -16,10 +16,10 @@ jobs:
       - name: 'Pull repo'
         uses: actions/checkout@v6
 
-      - name: 'Java 21'
+      - name: 'Java 25'
         uses: actions/setup-java@v5
         with:
-          java-version: 21
+          java-version: 25
           distribution: oracle
 
       - name: Set timezone

--- a/.github/workflows/bygg_og_deploy.yml
+++ b/.github/workflows/bygg_og_deploy.yml
@@ -31,10 +31,10 @@ jobs:
         uses: actions/checkout@v6
 
       # JAVA
-      - name: Java 21
+      - name: Java 25
         uses: actions/setup-java@v5
         with:
-          java-version: 21
+          java-version: 25
           distribution: temurin
 
       # Gradlew Build and run test

--- a/.github/workflows/bygg_og_deploy_sandbox.yml
+++ b/.github/workflows/bygg_og_deploy_sandbox.yml
@@ -22,10 +22,10 @@ jobs:
         uses: actions/checkout@v6
 
       # JAVA
-      - name: Java 21
+      - name: Java 25
         uses: actions/setup-java@v5
         with:
-          java-version: 21
+          java-version: 25
           distribution: temurin
 
       # Gradlew Build and run test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,7 @@
-#FROM ghcr.io/navikt/baseimages/temurin:21
-#COPY .nais/jvm-tuning.sh /init-scripts/
-#COPY build/libs/samordning-personoppslag.jar /app/app.jar
-
-FROM gcr.io/distroless/java21-debian12:nonroot
-
-ENV TZ="Europe/Oslo"
+FROM gcr.io/distroless/java25-debian13:nonroot
+ENV LANG="nb_NO.UTF-8" LC_ALL="nb_NO.UTF-8" TZ="Europe/Oslo"
 
 COPY build/libs/samordning-personoppslag.jar /app/app.jar
-
 COPY .nais/jvm-tuning.sh /init-scripts/
 
 CMD ["-jar", "/app/app.jar"]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
-val kotlinVersion = "2.3.0"
+val kotlinVersion = "2.3.20"
 val prometeusVersion = "1.16.1"
 val springbootVersion = "4.0.4"
 val springkafkaVersion="4.0.4"
@@ -19,7 +19,7 @@ val commonsLang3Version = "3.20.0"
 
 plugins {
     val pluginSpringBootVersion = "4.0.4"
-    val pluginKotlinVersion = "2.3.0"
+    val pluginKotlinVersion = "2.3.20"
 
     kotlin("jvm") version pluginKotlinVersion
     kotlin("plugin.spring") version pluginKotlinVersion
@@ -30,7 +30,7 @@ plugins {
 }
 
 group = "no.nav.pensjon"
-java.sourceCompatibility = JavaVersion.VERSION_21
+java.sourceCompatibility = JavaVersion.VERSION_25
 
 repositories {
     mavenCentral()
@@ -126,7 +126,7 @@ tasks {
 
     withType<KotlinJvmCompile>().configureEach {
         compilerOptions {
-            jvmTarget.set(JvmTarget.JVM_21)
+            jvmTarget.set(JvmTarget.JVM_25)
             freeCompilerArgs.add("-Xjsr305=strict")
         }
     }
@@ -136,7 +136,7 @@ tasks {
     }
 
     withType<Wrapper> {
-        gradleVersion = "8.13"
+        gradleVersion = "9.4.0"
     }
 
     configurations.all {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,28 +1,25 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
-val kotlinVersion = "2.2.21"
-val prometeusVersion = "1.15.5"
-val springbootVersion = "3.5.8"
-val springkafkaVersion="3.3.10"
-val springwebmvcpac4jVersion = "8.0.1"
-val springframeworkbomVersion = "6.2.12"
-val jacksonkotlinVersion = "2.20.1"
+val kotlinVersion = "2.3.0"
+val prometeusVersion = "1.16.1"
+val springbootVersion = "4.0.4"
+val springkafkaVersion="4.0.4"
+val springframeworkbomVersion = "7.0.2"
 val slf4jVersion = "2.0.17"
 val logstashlogbackVersion = "9.0"
-val tokensupportVersion = "5.0.40"
-val tokensupporttestVersion = "2.0.5"
+val tokensupportVersion = "6.0.4"
 val mockOAuth2ServerVersion = "3.0.1"
 val jakartaAnnotationApiVersion = "3.0.0"
 val jakartaInjectApiVersion = "2.0.1"
 val mockkVersion = "1.14.7"
-val springmockkVersion = "4.0.2"
+val springmockkVersion = "5.0.1"
 val junitplatformVersion = "6.0.1"
-val commonsLang3Version = "3.18.0"
+val commonsLang3Version = "3.20.0"
 
 plugins {
-    val pluginSpringBootVersion = "3.5.7"
-    val pluginKotlinVersion = "2.2.21"
+    val pluginSpringBootVersion = "4.0.4"
+    val pluginKotlinVersion = "2.3.0"
 
     kotlin("jvm") version pluginKotlinVersion
     kotlin("plugin.spring") version pluginKotlinVersion
@@ -60,10 +57,11 @@ dependencies {
 
     // Spring Boot & Framework
     implementation(platform("org.springframework.boot:spring-boot-dependencies:$springbootVersion"))
-    implementation("org.springframework.boot:spring-boot-starter-web:$springbootVersion")
-    implementation("org.springframework.boot:spring-boot-starter-aop:$springbootVersion")
-    implementation("org.springframework.boot:spring-boot-starter-actuator:$springbootVersion")
-    implementation("org.springframework.boot:spring-boot-actuator:$springbootVersion")
+    implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
+    implementation("org.springframework.boot:spring-boot-starter-aspectj")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("org.springframework.boot:spring-boot-actuator")
     implementation("org.springframework.boot:spring-boot-starter-cache")
     implementation(platform("org.springframework:spring-framework-bom:$springframeworkbomVersion"))
     implementation("org.springframework.retry:spring-retry:2.0.12")
@@ -73,7 +71,7 @@ dependencies {
 
     implementation("org.springframework.kafka:spring-kafka:$springkafkaVersion")
     testImplementation("org.springframework.kafka:spring-kafka-test:$springkafkaVersion")
-    implementation("io.confluent:kafka-avro-serializer:8.0.2") {
+    implementation("io.confluent:kafka-avro-serializer:8.1.1") {
         exclude(group = "org.apache.avro", module = "avro")
     }
     implementation("no.nav.pensjon:pensjon-pdl-avro-schema:2025.08.14-08.26-800400e1dc81")
@@ -83,9 +81,8 @@ dependencies {
     implementation("jakarta.annotation:jakarta.annotation-api:$jakartaAnnotationApiVersion")
     implementation("jakarta.inject:jakarta.inject-api:$jakartaInjectApiVersion")
 
-    // Kotlin
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonkotlinVersion")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonkotlinVersion")
+    // Kotlin + Jackson 3 (tools.jackson group = Jackson 3 artifacts, JavaTimeModule now built into jackson-databind)
+    implementation("tools.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion")
     implementation("org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion")
 
@@ -94,8 +91,6 @@ dependencies {
     implementation("no.nav.security:token-validation-jaxrs:$tokensupportVersion")
     implementation("no.nav.security:token-client-spring:$tokensupportVersion")
 
-    // Only used for starting up locally testing
-    implementation("no.nav.security:token-validation-test-support:$tokensupporttestVersion")
     testImplementation("no.nav.security:mock-oauth2-server:$mockOAuth2ServerVersion")
     testImplementation("no.nav.security:token-validation-spring-test:$tokensupportVersion")
 
@@ -106,16 +101,16 @@ dependencies {
     implementation("io.micrometer:micrometer-registry-prometheus:$prometeusVersion")
 
     // div
-    implementation("org.apache.commons:commons-lang3:3.19.0")
+    implementation("org.apache.commons:commons-lang3:$commonsLang3Version")
 
     // test
     testImplementation("com.ninja-squad:springmockk:$springmockkVersion")
-    testImplementation("org.pac4j:spring-webmvc-pac4j:$springwebmvcpac4jVersion")
 
     // mock - test
     testImplementation("io.mockk:mockk:$mockkVersion")
     testImplementation("org.junit.platform:junit-platform-suite-api:$junitplatformVersion")
-    testImplementation("org.springframework.boot:spring-boot-starter-test:$springbootVersion")
+    testImplementation("org.springframework.boot:spring-boot-starter-test")
+    testImplementation("org.springframework.boot:spring-boot-webmvc-test")
 }
 
 tasks {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -69,7 +69,7 @@ dependencies {
     //caffeine cache manager
     implementation("com.github.ben-manes.caffeine:caffeine:3.2.3")
 
-    implementation("org.springframework.kafka:spring-kafka:$springkafkaVersion")
+    implementation("org.springframework.boot:spring-boot-starter-kafka")
     testImplementation("org.springframework.kafka:spring-kafka-test:$springkafkaVersion")
     implementation("io.confluent:kafka-avro-serializer:8.1.1") {
         exclude(group = "org.apache.avro", module = "avro")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,9 +3,9 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 val kotlinVersion = "2.3.20"
 val prometeusVersion = "1.16.1"
-val springbootVersion = "4.0.4"
-val springkafkaVersion="4.0.4"
-val springframeworkbomVersion = "7.0.2"
+val springbootVersion = "4.0.6"
+val springkafkaVersion="4.0.5"
+val springframeworkbomVersion = "7.0.7"
 val slf4jVersion = "2.0.17"
 val logstashlogbackVersion = "9.0"
 val tokensupportVersion = "6.0.4"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/kotlin/no/nav/samordning/config/RestTemplateConfig.kt
+++ b/src/main/kotlin/no/nav/samordning/config/RestTemplateConfig.kt
@@ -8,7 +8,7 @@ import no.nav.samordning.person.pdl.Behandlingsnummer
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.boot.restclient.RestTemplateBuilder
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Profile

--- a/src/main/kotlin/no/nav/samordning/interceptor/AzureAdTokenRequestInterceptor.kt
+++ b/src/main/kotlin/no/nav/samordning/interceptor/AzureAdTokenRequestInterceptor.kt
@@ -1,7 +1,7 @@
 package no.nav.samordning.interceptor
 
 import org.slf4j.LoggerFactory
-import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.boot.restclient.RestTemplateBuilder
 import org.springframework.http.*
 import org.springframework.http.client.ClientHttpRequestExecution
 import org.springframework.http.client.ClientHttpRequestInterceptor

--- a/src/main/kotlin/no/nav/samordning/kodeverk/KodeverkClient.kt
+++ b/src/main/kotlin/no/nav/samordning/kodeverk/KodeverkClient.kt
@@ -1,6 +1,6 @@
 package no.nav.samordning.kodeverk
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.module.kotlin.jacksonObjectMapper
 import jakarta.annotation.PostConstruct
 import no.nav.samordning.mdc.MdcRequestFilter.Companion.REQUEST_ID_MDC_KEY
 import no.nav.samordning.metrics.MetricsHelper

--- a/src/main/kotlin/no/nav/samordning/kodeverk/KodeverkService.kt
+++ b/src/main/kotlin/no/nav/samordning/kodeverk/KodeverkService.kt
@@ -1,8 +1,7 @@
 package no.nav.samordning.kodeverk
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.KotlinModule
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
@@ -36,8 +35,9 @@ class KodeverkService(private val kodeverkClient: KodeverkClient) {
                 .writeValueAsString(data)
         }
 
-        fun mapperWithJavaTime(): ObjectMapper = jacksonObjectMapper()
-            .registerModule(JavaTimeModule())
+        fun mapperWithJavaTime(): JsonMapper = JsonMapper.builder()
+            .addModule(KotlinModule.Builder().build())
+            .build()
 
         fun Any.toJson() = mapAnyToJson(this)
     }

--- a/src/main/kotlin/no/nav/samordning/person/Controller.kt
+++ b/src/main/kotlin/no/nav/samordning/person/Controller.kt
@@ -38,7 +38,7 @@ class Controller(
 
     @PostMapping("/samperson")
     @ProtectedWithClaims("entraid")
-    fun hentSamPerson(@RequestBody request: PersonRequest) : ResponseEntity<PersonSamordning?> {
+    fun hentSamPerson(@RequestBody request: PersonRequest) : ResponseEntity<PersonSamordning> {
         try {
             Fodselsnummer.fra(request.fnr)
             return ResponseEntity.ok().body(personSamordningService.hentPersonSamordning(request.fnr))

--- a/src/main/kotlin/no/nav/samordning/person/pdl/PersonClient.kt
+++ b/src/main/kotlin/no/nav/samordning/person/pdl/PersonClient.kt
@@ -27,7 +27,7 @@ class PersonClient(
     internal fun hentPerson(ident: String): HentPersonResponse {
         val query = getGraphqlResource("/graphql/hentPerson.graphql")
         val request = GraphqlRequest(query, Variables(ident))
-        return pdlRestTemplate.postForObject<HentPersonResponse>(url, HttpEntity(request), HentPersonResponse::class).also {
+        return pdlRestTemplate.postForObject<HentPersonResponse>(url, HttpEntity(request), HentPersonResponse::class)!!.also {
             loggPdlFeil(it.errors)
         }
   }
@@ -39,7 +39,7 @@ class PersonClient(
     internal fun hentAdresseLegacy(ident: String): HentAdresseLegacyResponse {
         val query = getGraphqlResource("/graphql/hentAdresseLegacy.graphql")
         val request = GraphqlRequest(query, Variables(ident))
-        return pdlRestTemplate.postForObject<HentAdresseLegacyResponse>(url, HttpEntity(request), HentAdresseLegacyResponse::class).also {
+        return pdlRestTemplate.postForObject<HentAdresseLegacyResponse>(url, HttpEntity(request), HentAdresseLegacyResponse::class)!!.also {
             loggPdlFeil(it.errors)
         }
     }
@@ -51,7 +51,7 @@ class PersonClient(
     internal fun hentAdresse(ident: String): HentAdresseResponse {
         val query = getGraphqlResource("/graphql/hentAdresse.graphql")
         val request = GraphqlRequest(query, Variables(ident))
-        return pdlRestTemplate.postForObject<HentAdresseResponse>(url, HttpEntity(request))
+        return pdlRestTemplate.postForObject<HentAdresseResponse>(url, HttpEntity(request))!!
             .also { loggPdlFeil(it.errors) }
     }
 
@@ -64,7 +64,7 @@ class PersonClient(
         val query = getGraphqlResource("/graphql/hentPersonnavn.graphql")
         val request = GraphqlRequest(query, Variables(ident))
 
-        return pdlRestTemplate.postForObject<HentPersonnavnResponse>(url, HttpEntity(request), HentPersonnavnResponse::class).also {
+        return pdlRestTemplate.postForObject<HentPersonnavnResponse>(url, HttpEntity(request), HentPersonnavnResponse::class)!!.also {
             loggPdlFeil(it.errors)
         }
     }
@@ -77,7 +77,7 @@ class PersonClient(
         val query = getGraphqlResource("/graphql/hentAdressebeskyttelse.graphql")
         val request = GraphqlRequest(query, Variables(identer = listOf(identer)))
 
-        return pdlRestTemplate.postForObject(url, HttpEntity(request), AdressebeskyttelseResponse::class)
+        return pdlRestTemplate.postForObject<AdressebeskyttelseResponse>(url, HttpEntity(request), AdressebeskyttelseResponse::class)!!
     }
 
 
@@ -89,7 +89,7 @@ class PersonClient(
         val query = getGraphqlResource("/graphql/hentIdenter.graphql")
         val request = GraphqlRequest(query, Variables(ident))
 
-        return pdlRestTemplate.postForObject<IdenterResponse>(url, HttpEntity(request), IdenterResponse::class).also {
+        return pdlRestTemplate.postForObject<IdenterResponse>(url, HttpEntity(request), IdenterResponse::class)!!.also {
             loggPdlFeil(it.errors)
         }
     }
@@ -102,7 +102,7 @@ class PersonClient(
         val query = getGraphqlResource("/graphql/hentGeografiskTilknytning.graphql")
         val request = GraphqlRequest(query, Variables(ident))
 
-        return pdlRestTemplate.postForObject<GeografiskTilknytningResponse>(url, HttpEntity(request), GeografiskTilknytningResponse::class).also {
+        return pdlRestTemplate.postForObject<GeografiskTilknytningResponse>(url, HttpEntity(request), GeografiskTilknytningResponse::class)!!.also {
             loggPdlFeil(it.errors)
         }
     }

--- a/src/main/kotlin/no/nav/samordning/person/sam/PersonSamordningService.kt
+++ b/src/main/kotlin/no/nav/samordning/person/sam/PersonSamordningService.kt
@@ -111,7 +111,7 @@ class PersonSamordningService(
 
         val sivilstand = mapSivilstand(pdlSamPerson.sivilstand?.type?.name)
 
-        val dodsdato = pdlSamPerson.doedsfall?.doedsdato?.let { java.sql.Date.valueOf(it) as Date }
+        val dodsdato = pdlSamPerson.doedsfall?.doedsdato
 
         val utenlandsAdresse = when (pdlSamPerson.landkodeMedAdressevalg().second)
         {

--- a/src/main/kotlin/no/nav/samordning/person/sam/model/Person.kt
+++ b/src/main/kotlin/no/nav/samordning/person/sam/model/Person.kt
@@ -1,6 +1,6 @@
 package no.nav.samordning.person.sam.model
 
-import java.util.*
+import java.time.LocalDate
 
 data class Person(
     val fnr: String? = null,
@@ -8,6 +8,6 @@ data class Person(
     val mellomnavn: String? = null,
     val etternavn: String? = null,
     val sivilstand: String? = null,
-    val dodsdato: Date? = null,
+    val dodsdato: LocalDate? = null,
     val utbetalingsAdresse: AdresseSamordning? = null
 )

--- a/src/main/kotlin/no/nav/samordning/person/sam/model/PersonSamordning.kt
+++ b/src/main/kotlin/no/nav/samordning/person/sam/model/PersonSamordning.kt
@@ -1,6 +1,6 @@
 package no.nav.samordning.person.sam.model
 
-import java.util.*
+import java.time.LocalDate
 
 data class PersonSamordning(
     val fnr: String? = null,
@@ -10,7 +10,7 @@ data class PersonSamordning(
     val etternavn: String? = null,
     val diskresjonskode: String? = null,
     val sivilstand: String? = null,
-    val dodsdato: Date? = null,
+    val dodsdato: LocalDate? = null,
     val utenlandsAdresse: AdresseSamordning? = null,
     val tilleggsAdresse: AdresseSamordning? = null,
     val postAdresse: AdresseSamordning? = null,

--- a/src/main/kotlin/no/nav/samordning/personhendelse/PersonEndringHendelseProducer.kt
+++ b/src/main/kotlin/no/nav/samordning/personhendelse/PersonEndringHendelseProducer.kt
@@ -1,8 +1,7 @@
 package no.nav.samordning.personhendelse
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.KotlinModule
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.KotlinModule
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
@@ -16,9 +15,9 @@ class PersonEndringHendelseProducer(
     @Value("\${PERSON_ENDRING_KAFKA_TOPIC}") private val topic: String
 ) {
     private val logger: Logger = LoggerFactory.getLogger(javaClass)
-    private val objectMapper: ObjectMapper = ObjectMapper()
-        .registerModule(KotlinModule.Builder().build())
-        .registerModule(JavaTimeModule())
+    private val objectMapper: JsonMapper = JsonMapper.builder()
+        .addModule(KotlinModule.Builder().build())
+        .build()
 
     fun publiserPersonEndringHendelse(
         tpNr: List<String>,

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,6 +9,10 @@ spring:
     bootstrap-servers: ${KAFKA_BROKERS}
     security.protocol: SSL
 
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+
     consumer:
       group-id: ${KAFKA_GROUP_ID}
 

--- a/src/test/kotlin/no/nav/samordning/person/ControllerMVCTest.kt
+++ b/src/test/kotlin/no/nav/samordning/person/ControllerMVCTest.kt
@@ -1,10 +1,10 @@
 package no.nav.samordning.person
 
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
+import tools.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.module.kotlin.readValue
 import com.github.benmanes.caffeine.cache.Cache
 import com.ninjasquad.springmockk.MockkBean
+import org.springframework.kafka.core.KafkaTemplate
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.verify
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.*
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.cache.caffeine.CaffeineCacheManager
 import org.springframework.http.HttpEntity
@@ -71,7 +71,10 @@ internal class ControllerMVCTest {
     @MockkBean(relaxed = true, name = "tpRestTemplate")
     private lateinit var tpRestTemplate: RestTemplate
 
-    private val mapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+    @MockkBean(relaxed = true)
+    private lateinit var kafkaTemplate: KafkaTemplate<String, String>
+
+    private val mapper = jacksonObjectMapper()
     private val kodeverkPostnrResponse = mapper.readValue<KodeverkResponse>(javaClass.getResource("/kodeverk-api-v1-Postnummer.json")?.readText() ?: throw Exception("ikke funnet"))
     private val kodeverkLandResponse = mapper.readValue<KodeverkResponse>(javaClass.getResource("/kodeverk-api-v1-Landkoder.json")?.readText() ?: throw Exception("ikke funnet"))
     private val landkoder = javaClass.getResource("/kodeverk-landkoder.json")?.readText() ?: throw Exception("ikke funnet")

--- a/src/test/kotlin/no/nav/samordning/person/pdl/PdlPersonServiceTest.kt
+++ b/src/test/kotlin/no/nav/samordning/person/pdl/PdlPersonServiceTest.kt
@@ -1,7 +1,6 @@
 package no.nav.samordning.person.pdl
 
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.module.kotlin.jacksonObjectMapper
 import io.mockk.every
 import io.mockk.mockk
 import no.nav.samordning.kodeverk.KodeverkService
@@ -19,7 +18,7 @@ import java.time.LocalDateTime
 
 @TestInstance(Lifecycle.PER_CLASS)
 internal class PdlPersonServiceTest {
-    private val mapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+    private val mapper = jacksonObjectMapper()
 
     private val client = mockk<PersonClient>()
     private val kodeverkService = mockk<KodeverkService>()

--- a/src/test/kotlin/no/nav/samordning/person/pdl/PdlPersonTest.kt
+++ b/src/test/kotlin/no/nav/samordning/person/pdl/PdlPersonTest.kt
@@ -1,7 +1,6 @@
 package no.nav.samordning.person.pdl
 
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.module.kotlin.jacksonObjectMapper
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -18,7 +17,7 @@ internal class PdlPersonTest {
     private val mockPersonClient: PersonClient = mockk(relaxed = true)
     private val mockKodeverkService: KodeverkService = mockk(relaxed = true)
     private val mockPersonService = PersonServiceLegacy(mockPersonClient, mockKodeverkService)
-    private val mapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+    private val mapper = jacksonObjectMapper()
 
     @AfterEach
     fun after() {

--- a/src/test/kotlin/no/nav/samordning/person/pdl/RestTemplateConfigTest.kt
+++ b/src/test/kotlin/no/nav/samordning/person/pdl/RestTemplateConfigTest.kt
@@ -1,7 +1,7 @@
 package no.nav.samordning.person.pdl
 
 import org.springframework.boot.test.context.TestConfiguration
-import org.springframework.boot.web.client.RestTemplateBuilder
+import org.springframework.boot.restclient.RestTemplateBuilder
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Primary
 import org.springframework.core.Ordered

--- a/src/test/kotlin/no/nav/samordning/person/pdl/model/AdressebeskyttelseResponseTest.kt
+++ b/src/test/kotlin/no/nav/samordning/person/pdl/model/AdressebeskyttelseResponseTest.kt
@@ -1,6 +1,6 @@
 package no.nav.samordning.person.pdl.model
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.module.kotlin.jacksonObjectMapper
 import no.nav.samordning.person.pdl.model.AdressebeskyttelseGradering.STRENGT_FORTROLIG
 import no.nav.samordning.person.pdl.model.AdressebeskyttelseGradering.STRENGT_FORTROLIG_UTLAND
 import org.junit.jupiter.api.Assertions.*

--- a/src/test/kotlin/no/nav/samordning/person/pdl/model/HentPersonnavnResponseTest.kt
+++ b/src/test/kotlin/no/nav/samordning/person/pdl/model/HentPersonnavnResponseTest.kt
@@ -1,13 +1,12 @@
 package no.nav.samordning.person.pdl.model
 
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.module.kotlin.jacksonObjectMapper
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
 internal class HentPersonnavnResponseTest {
 
-    private val mapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+    private val mapper = jacksonObjectMapper()
 
     @Test
     fun `hentPersonnavn`() {

--- a/src/test/kotlin/no/nav/samordning/personhendelse/DoedsfallServiceTest.kt
+++ b/src/test/kotlin/no/nav/samordning/personhendelse/DoedsfallServiceTest.kt
@@ -1,7 +1,6 @@
 package no.nav.samordning.personhendelse
 
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.module.kotlin.jacksonObjectMapper
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
@@ -132,7 +131,7 @@ class DoedsfallServiceTest {
                 "bostedsadresse": null
             }
         """.trimIndent()
-        return jacksonObjectMapper().registerModule(JavaTimeModule()).readValue(json, Personhendelse::class.java)
+        return jacksonObjectMapper().readValue(json, Personhendelse::class.java)
     }
 
 

--- a/src/test/kotlin/no/nav/samordning/personhendelse/FolkeregisterServiceTest.kt
+++ b/src/test/kotlin/no/nav/samordning/personhendelse/FolkeregisterServiceTest.kt
@@ -1,7 +1,7 @@
 package no.nav.samordning.personhendelse
 
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.databind.MapperFeature
+import tools.jackson.databind.json.JsonMapper
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
@@ -58,7 +58,7 @@ class FolkeregisterServiceTest {
         }
 }
 
-    private fun mockPersonhendelse(nyttFnr: String = "24828296260", gammeltFnr: String = "25637424842", endringsType: Endringstype = Endringstype.OPPRETTET ): Personhendelse {
+    private fun mockPersonhendelse(nyttFnr: String = "24828296260", gammeltFnr: String = "25637424842", endringsType: Endringstype = Endringstype.OPPRETTET): Personhendelse {
         val json = """
             {
                 "hendelseId": "c53fded7-6b4e-434b-b5d8-e14769efa835", 
@@ -83,7 +83,10 @@ class FolkeregisterServiceTest {
                 "bostedsadresse": null
             }
         """.trimIndent()
-        return jacksonObjectMapper().registerModule(JavaTimeModule()).readValue(json, Personhendelse::class.java)
+        return JsonMapper.builder()
+            .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)
+            .build()
+            .readValue(json, Personhendelse::class.java)
     }
 
 

--- a/src/test/kotlin/no/nav/samordning/personhendelse/KafkaListenerTest.kt
+++ b/src/test/kotlin/no/nav/samordning/personhendelse/KafkaListenerTest.kt
@@ -1,10 +1,9 @@
 package no.nav.samordning.personhendelse
 
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.MapperFeature
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.json.JsonMapper
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import tools.jackson.databind.DeserializationFeature
+import tools.jackson.databind.MapperFeature
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.databind.json.JsonMapper
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
@@ -237,8 +236,8 @@ class KafkaListenerTest {
 
     fun configureObjectMapper(): ObjectMapper {
         return JsonMapper.builder()
-            .addModule(JavaTimeModule())
             .configure(MapperFeature.USE_ANNOTATIONS, false)
+            .enable(MapperFeature.ACCEPT_CASE_INSENSITIVE_PROPERTIES)
             .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
             .build()
     }

--- a/src/test/kotlin/no/nav/samordning/personhendelse/PersonEndringHendelseProducerTest.kt
+++ b/src/test/kotlin/no/nav/samordning/personhendelse/PersonEndringHendelseProducerTest.kt
@@ -1,9 +1,8 @@
 package no.nav.samordning.personhendelse
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.KotlinModule
-import com.fasterxml.jackson.module.kotlin.readValue
+import tools.jackson.databind.json.JsonMapper
+import tools.jackson.module.kotlin.KotlinModule
+import tools.jackson.module.kotlin.readValue
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -16,9 +15,9 @@ import org.junit.jupiter.api.Assertions.assertEquals
 class PersonEndringHendelseProducerTest {
     private lateinit var kafkaTemplate: KafkaTemplate<String, String>
     private lateinit var personEndringHendelseProducer: PersonEndringHendelseProducer
-    private val objectMapper: ObjectMapper = ObjectMapper()
-        .registerModule(KotlinModule.Builder().build())
-        .registerModule(JavaTimeModule())
+    private val objectMapper: JsonMapper = JsonMapper.builder()
+        .addModule(KotlinModule.Builder().build())
+        .build()
 
     @BeforeEach
     fun setup() {

--- a/src/test/kotlin/no/nav/samordning/personhendelse/SivilstandServiceTest.kt
+++ b/src/test/kotlin/no/nav/samordning/personhendelse/SivilstandServiceTest.kt
@@ -1,7 +1,6 @@
 package no.nav.samordning.personhendelse
 
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.module.kotlin.jacksonObjectMapper
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
@@ -97,7 +96,7 @@ class SivilstandServiceTest {
                 "bostedsadresse": null
             }
         """.trimIndent()
-        return jacksonObjectMapper().registerModule(JavaTimeModule()).readValue(json, Personhendelse::class.java)
+        return jacksonObjectMapper().readValue(json, Personhendelse::class.java)
     }
 
     private fun mockPdlPerson(): PdlPerson {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -5,6 +5,10 @@ PDL_URL: http://localhost/graphql
 SAM_URL: http://localhost/api/oppdaterpersonalia
 TP_URL: http://localhost/api/tjenestepensjon
 
+spring:
+  kafka:
+    bootstrap-servers: localhost:9092
+
 pdl:
   kafka:
     autoStartup: false


### PR DESCRIPTION
… token-support 6.0.4

- Spring Boot 3.5.8 → 4.0.4 (+ plugin 3.5.7 → 4.0.4)
- Spring Kafka 3.3.10 → 4.0.4
- Spring Framework BOM 6.2.12 → 7.0.2
- Kotlin 2.2.21 → 2.3.0
- token-support 5.0.40 → 6.0.4
- Micrometer/Prometheus 1.15.5 → 1.16.1
- springmockk 4.0.2 → 5.0.1
- kafka-avro-serializer 8.0.2 → 8.1.1
- commons-lang3 3.18.0 → 3.20.0

Jackson 3 migration (com.fasterxml.jackson → tools.jackson):
- Updated all imports to tools.jackson.* in 13 source files
- Replaced registerModule() with JsonMapper.builder().addModule().build()
- JavaTimeModule now built-in to jackson-databind 3.x; removed explicit dep
- Removed jackson-module-kotlin version override (BOM-managed)
- KafkaListenerTest/FolkeregisterServiceTest: added ACCEPT_CASE_INSENSITIVE_PROPERTIES to handle Avro field names (capital first letter) vs JSON (lowercase first letter)

Spring Boot 4 / Spring Framework 7 breaking changes:
- spring-boot-starter-aop → spring-boot-starter-aspectj
- RestTemplateBuilder moved to org.springframework.boot.restclient
- @AutoConfigureMockMvc moved to org.springframework.boot.webmvc.test.autoconfigure (new dep: spring-boot-webmvc-test)
- ResponseEntity<T> generic type must be non-nullable
- postForObject() returns T? in Spring Framework 7 assertions
- Added spring-boot-starter-validation (no longer pulled in transitively)

Model / data fixes:
- PersonSamordning.dodsdato and Person.dodsdato: Date → LocalDate (removes java.sql.Date timezone conversion bug; Jackson 3 serialises LocalDate as yyyy-MM-dd without any @JsonFormat needed)
- PersonSamordningService: removed java.sql.Date.valueOf() conversion

Removed dead dependencies:
- token-validation-test-support:2.0.5 (Spring Boot 2.x / javax.* artifact)
- spring-webmvc-pac4j (unused in source)

Test fixes:
- ControllerMVCTest: added @MockkBean for KafkaTemplate<String,String>
- test application.yml: added spring.kafka.bootstrap-servers for Spring Boot 4